### PR TITLE
PP-8263 Update the `pre-commit` and `detect-secrets` setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/Yelp/detect-secrets
+  rev: f6027a0521e044ba46e54611cabd787b7a88d1a9 
+  hooks:
+    - id: detect-secrets
+      args: ['--baseline', '.secrets.baseline']
+      exclude: package.lock.json

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,19 +1,15 @@
 {
-  "exclude": {
-    "files": null,
-    "lines": null
-  },
-  "generated_at": "2021-08-03T12:55:42Z",
+  "version": "1.1.0",
   "plugins_used": [
-    {
-      "name": "AWSKeyDetector"
-    },
     {
       "name": "ArtifactoryDetector"
     },
     {
-      "base64_limit": 4.5,
-      "name": "Base64HighEntropyString"
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
     },
     {
       "name": "BasicAuthDetector"
@@ -22,8 +18,8 @@
       "name": "CloudantDetector"
     },
     {
-      "hex_limit": 3,
-      "name": "HexHighEntropyString"
+      "name": "HexHighEntropyString",
+      "limit": 3
     },
     {
       "name": "IbmCloudIamDetector"
@@ -35,8 +31,8 @@
       "name": "JwtTokenDetector"
     },
     {
-      "keyword_exclude": null,
-      "name": "KeywordDetector"
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
     },
     {
       "name": "MailchimpDetector"
@@ -57,171 +53,72 @@
       "name": "TwilioKeyDetector"
     }
   ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
   "results": {
-    "src/go.sum": [
+    ".pre-commit-config.yaml": [
       {
-        "hashed_secret": "256ec8372ee3e7512177a290c0744f68d04d0e31",
+        "type": "Hex High Entropy String",
+        "filename": ".pre-commit-config.yaml",
+        "hashed_secret": "d8371c23f86b4df4be2854848f6f28f13d7582f5",
         "is_verified": false,
-        "line_number": 1,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "59c6c1d225e5a0f3dd19d74893c21d4eb54a0685",
-        "is_verified": false,
-        "line_number": 2,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "224fa2aa9d9bc6bcb032d31cbafe70aa9c30e4e7",
-        "is_verified": false,
-        "line_number": 3,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "4dbbe18874344f8a812138c0c9b17841a5fab11d",
-        "is_verified": false,
-        "line_number": 4,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "340de3a87bd07a3507a264d30d7e0adafe842654",
-        "is_verified": false,
-        "line_number": 5,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "f525cd95ed08368deccd4794a2f68c3a7410ddfe",
-        "is_verified": false,
-        "line_number": 6,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "c98951d055a7c203d71d775d03ca7dfa61a3554e",
-        "is_verified": false,
-        "line_number": 7,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "f0520c90d3a7ce5b863c0e8ddc755d30585d94a0",
-        "is_verified": false,
-        "line_number": 8,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "c7650183a346ae042dc23cca37346be944b530e1",
-        "is_verified": false,
-        "line_number": 9,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "6a4a1948d9e9978e41ee2d466928b91e8ac5d54b",
-        "is_verified": false,
-        "line_number": 10,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "c382813ad978b45fb54312f408087e014b4374eb",
-        "is_verified": false,
-        "line_number": 11,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "f16e20544c05634663c76b999b6707da9f0ecbcc",
-        "is_verified": false,
-        "line_number": 12,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "0918088df56ab0144ab80845726914b6f5762aa9",
-        "is_verified": false,
-        "line_number": 13,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "6d1620ca591257020f2bea1872e4e572f6eba61e",
-        "is_verified": false,
-        "line_number": 14,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "3bbee69c41c25a30b8b19a37c6b77570b259574e",
-        "is_verified": false,
-        "line_number": 15,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "0a8ed0038b47fe6328f04a9ddf48588c6e985799",
-        "is_verified": false,
-        "line_number": 16,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "0ce1bbf44cfc3e9ac535b22293940f5ace10a031",
-        "is_verified": false,
-        "line_number": 17,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "ebce33ed93c15294766862efead26a0fe7c1b480",
-        "is_verified": false,
-        "line_number": 19,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "6c76abe4bb26384b9ff06c9ef66352708b9368f1",
-        "is_verified": false,
-        "line_number": 20,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "75ab864f84af321656ed52959dd5be6b7d1ecb09",
-        "is_verified": false,
-        "line_number": 21,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "4ef548550ab47a3cf6306d34075d8065ed95d0f1",
-        "is_verified": false,
-        "line_number": 22,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "aa945027601e7b92be504f177761e51cd2fc9293",
-        "is_verified": false,
-        "line_number": 23,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "544f95865e9625c5f51acff5a827e1fdfcbabf1a",
-        "is_verified": false,
-        "line_number": 24,
-        "type": "Base64 High Entropy String"
-      },
-      {
-        "hashed_secret": "0bfcf978179e9b9371d132d9fd4065909f1fa3e6",
-        "is_verified": false,
-        "line_number": 25,
-        "type": "Base64 High Entropy String"
+        "line_number": 3
       }
     ],
     "src/process_logger_test.go": [
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/process_logger_test.go",
         "hashed_secret": "55a1884f23c03158e18f5f1b82bcc6d1bd45a7fe",
         "is_verified": false,
-        "line_number": 84,
-        "type": "Base64 High Entropy String"
+        "line_number": 84
       },
       {
+        "type": "Base64 High Entropy String",
+        "filename": "src/process_logger_test.go",
         "hashed_secret": "9c5f0216cee5c2e68fa5fc65e8a842c9732466d5",
         "is_verified": false,
-        "line_number": 167,
-        "type": "Base64 High Entropy String"
+        "line_number": 167
       }
     ]
   },
-  "version": "0.13.1",
-  "word_list": {
-    "file": null,
-    "hash": null
-  }
+  "generated_at": "2021-08-17T15:57:13Z"
 }


### PR DESCRIPTION
- Add a local `.pre-commit.yaml`
  - This will run `detect-secrets` when you try to commit a file.
- Update the existing `.secrets.baseline` file
  - To ignore the SHA specified in the `.pre-commit.yaml`